### PR TITLE
hide tooltips when focusable target receives esc

### DIFF
--- a/d2l-tooltip.html
+++ b/d2l-tooltip.html
@@ -350,6 +350,7 @@ Polymer-based web component for a D2L tooltip
 					this.listen(this._target, 'mouseleave', 'hide');
 					this.listen(this._target, 'blur', 'hide');
 					this.listen(this._target, 'tap', '_toggle');
+					this.listen(this._target, 'keydown', '_onKeydown');
 				}
 			},
 
@@ -390,12 +391,20 @@ Polymer-based web component for a D2L tooltip
 					this.unlisten(this._target, 'focus', 'show');
 					this.unlisten(this._target, 'mouseleave', 'hide');
 					this.unlisten(this._target, 'blur', 'hide');
-					this.unlisten(this._target, 'tap', 'hide');
+					this.unlisten(this._target, 'tap', '_toggle');
+					this.unlisten(this._target, 'keydown', '_onKeydown');
 				}
 			},
 
 			_onIronResize: function() {
 				this.updatePosition();
+			},
+
+			_onKeydown: function(e) {
+				if (e.keyCode === 27) {
+					this._tappedOn = false;
+					this.showing = false;
+				}
 			}
 		});
 	</script>

--- a/d2l-tooltip.html
+++ b/d2l-tooltip.html
@@ -401,7 +401,8 @@ Polymer-based web component for a D2L tooltip
 			},
 
 			_onKeydown: function(e) {
-				if (e.keyCode === 27) {
+				var keycode_esc = 27;
+				if (e.keyCode === keycode_esc) {
 					this._tappedOn = false;
 					this.showing = false;
 				}

--- a/demo/index.html
+++ b/demo/index.html
@@ -50,25 +50,25 @@
   </head>
   <body class="d2l-typography">
 		<div class="hover-link-container">
-		<span class="box" id="bottom">Hover me (bottom)</span>
-		<d2l-tooltip id="bottomTooltip" position="bottom" for="bottom">Bottom</d2l-tooltip>
-		<br />
-		<span class="box" id="top">Hover me (top)</span>
-		<d2l-tooltip id="topTooltip" position="top" for="top">Top</d2l-tooltip>
-		<br />
-		<span class="box" id="left">Hover me (left)</span>
-		<d2l-tooltip id="leftTooltip" position="left" for="left">Left</d2l-tooltip>
-		<br />
-		<span class="box" id="right">Hover me (right)</span>
-		<d2l-tooltip id="rightTooltip" position="right" for="right">Right</d2l-tooltip>
-    <br />
-    <span class="box" id="mixin">Mixin Tooltip (right)</span>
-		<d2l-tooltip id="mixinTooltip" class="mixin-tooltip" position="right" for="mixin">
-      Use custom parameters to style the tooltip.
-		</d2l-tooltip>
-		<br />
-		<span class="box" id="right-tap-toggle">Tap me (right)</span>
-		<d2l-tooltip id="rightTapTooltip" position="right" for="right-tap-toggle" tap-toggle>Right Tap Toggle</d2l-tooltip>
+			<span class="box" id="bottom">Hover me (bottom)</span>
+			<d2l-tooltip position="bottom" for="bottom">Bottom</d2l-tooltip>
+			<br />
+			<span class="box" id="top">Hover me (top)</span>
+			<d2l-tooltip position="top" for="top">Top</d2l-tooltip>
+			<br />
+			<span class="box" id="left">Hover me (left)</span>
+			<d2l-tooltip position="left" for="left">Left</d2l-tooltip>
+			<br />
+			<span class="box" id="right">Hover me (right)</span>
+			<d2l-tooltip position="right" for="right">Right</d2l-tooltip>
+			<br />
+			<span class="box" id="mixin">Mixin Tooltip (right)</span>
+			<d2l-tooltip class="mixin-tooltip" position="right" for="mixin">
+				Use custom parameters to style the tooltip.
+			</d2l-tooltip>
+			<br />
+			<span class="box" id="right-tap-toggle" tabindex="0">Tap me (right)</span>
+			<d2l-tooltip position="right" for="right-tap-toggle" tap-toggle>Right Tap Toggle</d2l-tooltip>
 		</div>
 	</body>
 </html>


### PR DESCRIPTION
Focusable elements with tooltips have them shown on focus. As per [ARIA best practices](https://www.w3.org/TR/wai-aria-practices/#tooltip), they should be dismissable via the `escape` key. This does that.