### PR TITLE
Do not close on propagated event

### DIFF
--- a/d2l-tooltip.html
+++ b/d2l-tooltip.html
@@ -288,6 +288,7 @@ Polymer-based web component for a D2L tooltip
 				}
 
 				this.showing = false;
+				this.unlisten(this.document, 'tap', '_documentClickListener');
 			},
 
 			updatePosition: function() {
@@ -363,7 +364,6 @@ Polymer-based web component for a D2L tooltip
 				this._tappedOn = !this._tappedOn;
 				if (!this._tappedOn) {
 					this.hide();
-					this.unlisten(this.document, 'tap', '_documentClickListener');
 				} else {
 					setTimeout(function() { this.listen(this.document, 'tap', '_documentClickListener'); }.bind(this), 0);
 					this.show();
@@ -374,7 +374,6 @@ Polymer-based web component for a D2L tooltip
 				if (e.target.id !== this._target.id) {
 					this._tappedOn = false;
 					this.hide(undefined, true);
-					this.unlisten(this.document, 'tap', '_documentClickListener');
 				}
 			},
 
@@ -410,7 +409,7 @@ Polymer-based web component for a D2L tooltip
 				var keycode_esc = 27;
 				if (e.keyCode === keycode_esc) {
 					this._tappedOn = false;
-					this.showing = false;
+					this.hide();
 				}
 			}
 		});

--- a/d2l-tooltip.html
+++ b/d2l-tooltip.html
@@ -365,7 +365,7 @@ Polymer-based web component for a D2L tooltip
 					this.hide();
 					this.unlisten(this.document, 'tap', '_documentClickListener');
 				} else {
-					this.listen(this.document, 'tap', '_documentClickListener');
+					setTimeout(function() { this.listen(this.document, 'tap', '_documentClickListener'); }.bind(this), 0);
 					this.show();
 				}
 			},
@@ -374,6 +374,7 @@ Polymer-based web component for a D2L tooltip
 				if (e.target.id !== this._target.id) {
 					this._tappedOn = false;
 					this.hide(undefined, true);
+					this.unlisten(this.document, 'tap', '_documentClickListener');
 				}
 			},
 


### PR DESCRIPTION
In trying to consume this with `tap-toggle` on the document listener was receiving the same `tap` event that triggered the toggle. The `setTimeout` will now delay wiring up to the document listener until after that event has flowed through, only listening to subsequent events.

I also noticed that you could get into a state where the document listener wasn't unlistened when you clicked outside of the target, and then toggle-ing on the tooltip would immediately close it, so this should unlisten to that now.