### PR TITLE
Fix for when the tooltip is inside a relative container

### DIFF
--- a/d2l-tooltip.html
+++ b/d2l-tooltip.html
@@ -292,6 +292,13 @@ Polymer-based web component for a D2L tooltip
 				this.unlisten(this.document, 'tap', '_documentClickListener');
 			},
 
+			getScrollVals: function() {
+				var parentStyle = window.getComputedStyle(this.offsetParent);
+				return (parentStyle && parentStyle.getPropertyValue('position') === 'static') ?
+					{ xScroll: window.pageXOffset, yScroll: window.pageYOffset } :
+					{ xScroll: 0, yScroll: 0 };
+			},
+
 			updatePosition: function() {
 				if (!this.customTarget && (!this._target || !this.offsetParent)) {
 					return;
@@ -304,19 +311,14 @@ Polymer-based web component for a D2L tooltip
 				var targetRect = this.customTarget ? this.customTarget : this._target.getBoundingClientRect();
 				var thisRect = this.getBoundingClientRect();
 
-				var xScroll = window.pageXOffset;
-				var yScroll = window.pageYOffset;
+				var scrollVals = this.getScrollVals();
+				var xScroll = scrollVals.xScroll;
+				var yScroll = scrollVals.yScroll;
 
 				var horizontalCenterOffset = (targetRect.width - thisRect.width) / 2;
 				var verticalCenterOffset = (targetRect.height - thisRect.height) / 2;
 				var targetLeft = targetRect.left - parentRect.left;
 				var targetTop = targetRect.top - parentRect.top;
-
-				var parentStyle = window.getComputedStyle(this.offsetParent);
-				if (parentStyle && parentStyle.getPropertyValue('position') === 'relative') {
-					yScroll = 0;
-					xScroll = 0;
-				}
 
 				var tooltipLeft, tooltipTop;
 				switch (this.position) {

--- a/d2l-tooltip.html
+++ b/d2l-tooltip.html
@@ -312,6 +312,12 @@ Polymer-based web component for a D2L tooltip
 				var targetLeft = targetRect.left - parentRect.left;
 				var targetTop = targetRect.top - parentRect.top;
 
+				var parentStyle = window.getComputedStyle(this.offsetParent);
+				if (parentStyle && parentStyle.getPropertyValue('position') === 'relative') {
+					yScroll = 0;
+					xScroll = 0;
+				}
+
 				var tooltipLeft, tooltipTop;
 				switch (this.position) {
 					case 'top':

--- a/demo/index.html
+++ b/demo/index.html
@@ -23,6 +23,19 @@
 				align-items: center;
 				text-align: center;
 			}
+
+			.container {
+				background: lightgoldenrodyellow;
+				width: 500px;
+				height: 500px;
+				overflow: hidden;
+				margin-top: 20px;
+				position: relative;
+			}
+
+			.contained {
+				margin-top: 40px;
+			}
 		</style>
 		<custom-style include="d2l-typography">
 			<style is="custom-style" include="d2l-typography">
@@ -75,6 +88,13 @@
 			<br />
 			<button id="aria-button2">Focus me, too</button>
 			<d2l-tooltip position="right" for="aria-button2">I have a generated id</d2l-tooltip>
+			<br />
+			<div class="container">
+				<div class="contained">
+					<span class="box" id="top-contained">Hover me (top)</span>
+					<d2l-tooltip position="top" showing for="top-contained">This is at the top but should also be too wide for normal</d2l-tooltip>
+				</div>
+			</div>
 		</div>
 	</body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -31,6 +31,7 @@
 				overflow: hidden;
 				margin-top: 20px;
 				position: relative;
+				padding: 30px;
 			}
 
 			.contained {

--- a/tooltip.test.js
+++ b/tooltip.test.js
@@ -22,11 +22,12 @@ var browsers = {
 	// 	size: '1400x900',
 	// 	tags: ['no-d2l-shadow']
 	// }),
-	chromeMac: new SauceBrowserFactory({
-		browser: 'Chrome',
-		platform: 'SIERRA',
-		size: '1400x900'
-	}),
+	// REMOVING DUE TO CHROME WEBDRIVER ISSUE
+	// chromeMac: new SauceBrowserFactory({
+	// 	browser: 'Chrome',
+	// 	platform: 'SIERRA',
+	// 	size: '1400x900'
+	// }),
 	/* Safari and Firefox throw mouseMoveTo selenium errors trying to execute the hover, so skipping them */
 	// safariMac: new SauceBrowserFactory({
 	// 	browser: 'Safari',


### PR DESCRIPTION
It was taking scroll into account when it shouldn't have been doing that if there was a relative parent

I wonder if the reason it worked in the richtext was because `window.pageYOffset`  was 0 due to immersive page