### PR TITLE
Boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ Use the `postition` attribute to place the tooltip to the top, bottom, left, or 
 <d2l-tooltip for="target" position="right">Hello world!</d2l-tooltip>
 ```
 
+To constrain your tooltip to a certain area, pass in a `boundaries` property containing the pixel amounts you want the tooltip to be restricted to. Currently only the left and right boundaries are supported for the top and bottom positions.
+
+```javascript
+{ left: 10, right: 200 }
+```
+
 Custom CSS properties for styling:
 
 - All three properties should be set to style the box correctly:

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Use the `postition` attribute to place the tooltip to the top, bottom, left, or 
 <d2l-tooltip for="target" position="right">Hello world!</d2l-tooltip>
 ```
 
-To constrain your tooltip to a certain area, pass in a `boundaries` property containing the pixel amounts you want the tooltip to be restricted to. Currently only the left and right boundaries are supported for the top and bottom positions.
+To constrain your tooltip to a certain area, pass in a `boundary` property containing the pixel amounts you want the tooltip to be restricted to. Currently only the left and right boundary properties are supported for the top and bottom positions.
 
 ```javascript
 { left: 10, right: 200 }

--- a/d2l-tooltip.html
+++ b/d2l-tooltip.html
@@ -297,21 +297,40 @@ Polymer-based web component for a D2L tooltip
 				this.unlisten(this.document, 'tap', '_documentClickListener');
 			},
 
-			getScrollVals: function() {
+			updatePosition: function() {
+				if (!this.customTarget && (!this._target || !this.offsetParent)) {
+					return;
+				}
+
+				var targetRect = this.customTarget ? this.customTarget : this._target.getBoundingClientRect();
+				var thisRect = this.getBoundingClientRect();
+				var parentRect = (this.customTarget || this.offsetParent.tagName === 'BODY') ?
+					{ left: 0, top: 0, right: 0, bottom: 0 } :
+					this.offsetParent.getBoundingClientRect();
+
+				var targetPositions = this._getTargetPositions(targetRect, parentRect);
+				var tooltipPositions = this._getTooltipPositions(targetPositions, thisRect, targetRect);
+				var boundaryShifts = this._updateTooltipPositionsForBoundary(tooltipPositions, parentRect);
+
+				this._setTooltipStyle(tooltipPositions, targetPositions);
+				this._setTriangleStyle(thisRect, tooltipPositions, targetPositions, boundaryShifts);
+			},
+
+			_getScrollVals: function() {
 				var parentStyle = window.getComputedStyle(this.offsetParent);
 				return (parentStyle && parentStyle.getPropertyValue('position') === 'static') ?
 					{ xScroll: window.pageXOffset, yScroll: window.pageYOffset } :
 					{ xScroll: 0, yScroll: 0 };
 			},
 
-			getOffsets: function(targetRect, thisRect) {
+			_getOffsets: function(targetRect, thisRect) {
 				return {
 					horizontalCenterOffset: (targetRect.width - thisRect.width) / 2,
 					verticalCenterOffset: (targetRect.height - thisRect.height) / 2
 				};
 			},
 
-			getTargetPositions: function(targetRect, parentRect) {
+			_getTargetPositions: function(targetRect, parentRect) {
 				var left = targetRect.left - parentRect.left;
 				var right = parentRect.right - targetRect.right;
 				return {
@@ -322,13 +341,13 @@ Polymer-based web component for a D2L tooltip
 				};
 			},
 
-			getBoundaryWidth: function() {
+			get boundaryWidth() {
 				return this.boundaries.right - this.boundaries.left;
 			},
 
-			getTooltipPositions: function(targetPositions, thisRect, targetRect) {
-				var offsets = this.getOffsets(targetRect, thisRect);
-				var scrollVals = this.getScrollVals();
+			_getTooltipPositions: function(targetPositions, thisRect, targetRect) {
+				var offsets = this._getOffsets(targetRect, thisRect);
+				var scrollVals = this._getScrollVals();
 
 				var horizontalCenterOffset = offsets.horizontalCenterOffset;
 				var verticalCenterOffset = offsets.verticalCenterOffset;
@@ -370,20 +389,27 @@ Polymer-based web component for a D2L tooltip
 				return this.boundaries && (this.position === 'top' || this.position === 'bottom');
 			},
 
-			_shouldPositionUsingLeft: function(targetPositions) {
-				return !this._useBoundaries() || targetPositions.xCenter > this.getBoundaryWidth() / 4;
-			},
-
-			updatetooltipPositionsForBoundary: function(tooltipPositions, parentRect) {
+			_updateTooltipPositionsForBoundary: function(tooltipPositions, parentRect) {
 				if (!this._useBoundaries()) {
 					return;
 				}
 
+				var prevLeft = tooltipPositions.left;
+				var prevRight = tooltipPositions.right;
 				tooltipPositions.left = Math.max(this.boundaries.left, tooltipPositions.left);
 				tooltipPositions.right = Math.max(parentRect.width - this.boundaries.right, tooltipPositions.right);
+
+				return {
+					leftShift: tooltipPositions.left - prevLeft,
+					rightShift: tooltipPositions.right - prevRight
+				};
 			},
 
-			setTooltipStyle: function(tooltipPositions, targetPositions) {
+			_shouldPositionUsingLeft: function(targetPositions) {
+				return !this._useBoundaries() || targetPositions.xCenter > this.boundaryWidth / 4;
+			},
+
+			_setTooltipStyle: function(tooltipPositions, targetPositions) {
 				if (this._shouldPositionUsingLeft(targetPositions)) {
 					this.style.left = tooltipPositions.left + 'px';
 					this.style.right = 'auto';
@@ -395,7 +421,7 @@ Polymer-based web component for a D2L tooltip
 				this.style.top = tooltipPositions.top + 'px';
 
 				if (this.boundaries) {
-					this.style.maxWidth = this.getBoundaryWidth() + 'px';
+					this.style.maxWidth = this.boundaryWidth + 'px';
 				}
 
 				if (this.tooltipPadding) {
@@ -403,39 +429,26 @@ Polymer-based web component for a D2L tooltip
 				}
 			},
 
-			setTriangleStyle: function(thisRect, tooltipPositions, targetPositions) {
+			_setTriangleStyle: function(thisRect, tooltipPositions, targetPositions, boundaryShifts) {
 				if (!this._useBoundaries()) {
 					return;
 				}
 
-				// ABS?
-				// TODO: CURRENTLY WORKING ON THIS
+				var tooltipTriangle = this.$$('.d2l-tooltip-triangle');
+
 				if (this._shouldPositionUsingLeft(targetPositions)) {
-					var leftShift = Math.abs(tooltipPositions.left - Math.max(this.boundaries.left, tooltipPositions.left));
-					var triangleLeft = Math.max((thisRect.width / 2) - leftShift - 8, 8);
-					Polymer.dom(this.$.tooltip).querySelector('.d2l-tooltip-triangle').style.left = triangleLeft + 'px';
+					var triangleLeft = this._calculateTriangleShift(thisRect, boundaryShifts.leftShift);
+					tooltipTriangle.style.left = triangleLeft + 'px';
+					tooltipTriangle.style.right = 'auto';
+				} else {
+					var triangleRight = this._calculateTriangleShift(thisRect, boundaryShifts.rightShift);
+					tooltipTriangle.style.left = 'auto';
+					tooltipTriangle.style.right = triangleRight + 'px';
 				}
 			},
 
-			updatePosition: function() {
-				if (!this.customTarget && (!this._target || !this.offsetParent)) {
-					return;
-				}
-
-				var parentRect = (this.customTarget || this.offsetParent.tagName === 'BODY') ?
-					{ left: 0, top: 0, right: 0, bottom: 0 } :
-					this.offsetParent.getBoundingClientRect();
-
-				var targetRect = this.customTarget ? this.customTarget : this._target.getBoundingClientRect();
-				var thisRect = this.getBoundingClientRect();
-
-				var targetPositions = this.getTargetPositions(targetRect, parentRect);
-
-				var tooltipPositions = this.getTooltipPositions(targetPositions, thisRect, targetRect);
-				this.updatetooltipPositionsForBoundary(tooltipPositions, parentRect);
-
-				this.setTooltipStyle(tooltipPositions, targetPositions);
-				this.setTriangleStyle(thisRect, tooltipPositions, targetPositions);
+			_calculateTriangleShift: function(thisRect, shiftVal) {
+				return Math.max((thisRect.width / 2) - shiftVal - 8, 8);
 			},
 
 			get document() {

--- a/d2l-tooltip.html
+++ b/d2l-tooltip.html
@@ -218,7 +218,7 @@ Polymer-based web component for a D2L tooltip
 					value: false
 				},
 
-				boundaries: {
+				boundary: {
 					type: Object,
 					value: null
 				},
@@ -336,41 +336,38 @@ Polymer-based web component for a D2L tooltip
 				return {
 					left: left,
 					right: right,
-					xCenter: (right - left) / 2,
+					horizontalCenter: (right - left) / 2,
 					top: targetRect.top - parentRect.top
 				};
 			},
 
 			get boundaryWidth() {
-				return this.boundaries.right - this.boundaries.left;
+				return this.boundary.right - this.boundary.left;
 			},
 
 			_getTooltipPositions: function(targetPositions, thisRect, targetRect) {
 				var offsets = this._getOffsets(targetRect, thisRect);
 				var scrollVals = this._getScrollVals();
 
-				var horizontalCenterOffset = offsets.horizontalCenterOffset;
-				var verticalCenterOffset = offsets.verticalCenterOffset;
-
 				var tooltipLeft, tooltipTop, tooltipRight;
 				switch (this.position) {
 					case 'top':
-						tooltipLeft = targetPositions.left + horizontalCenterOffset;
-						tooltipRight = targetPositions.right + horizontalCenterOffset;
+						tooltipLeft = targetPositions.left + offsets.horizontalCenterOffset;
+						tooltipRight = targetPositions.right + offsets.horizontalCenterOffset;
 						tooltipTop = targetPositions.top - thisRect.height - this.offset;
 						break;
 					case 'bottom':
-						tooltipLeft = targetPositions.left + horizontalCenterOffset;
-						tooltipRight = targetPositions.right + horizontalCenterOffset;
+						tooltipLeft = targetPositions.left + offsets.horizontalCenterOffset;
+						tooltipRight = targetPositions.right + offsets.horizontalCenterOffset;
 						tooltipTop = targetPositions.top + targetRect.height + this.offset;
 						break;
 					case 'left':
 						tooltipLeft = targetPositions.left - thisRect.width - this.offset;
-						tooltipTop = targetPositions.top + verticalCenterOffset;
+						tooltipTop = targetPositions.top + offsets.verticalCenterOffset;
 						break;
 					case 'right':
 						tooltipLeft = targetPositions.left + targetRect.width + this.offset;
-						tooltipTop = targetPositions.top + verticalCenterOffset;
+						tooltipTop = targetPositions.top + offsets.verticalCenterOffset;
 						break;
 				}
 
@@ -386,7 +383,7 @@ Polymer-based web component for a D2L tooltip
 
 			_useBoundaries: function() {
 				// Boundaries currently only supported with top/bottom positions
-				return this.boundaries && (this.position === 'top' || this.position === 'bottom');
+				return this.boundary && (this.position === 'top' || this.position === 'bottom');
 			},
 
 			_updateTooltipPositionsForBoundary: function(tooltipPositions, parentRect) {
@@ -396,8 +393,8 @@ Polymer-based web component for a D2L tooltip
 
 				var prevLeft = tooltipPositions.left;
 				var prevRight = tooltipPositions.right;
-				tooltipPositions.left = Math.max(this.boundaries.left, tooltipPositions.left);
-				tooltipPositions.right = Math.max(parentRect.width - this.boundaries.right, tooltipPositions.right);
+				tooltipPositions.left = Math.max(this.boundary.left, tooltipPositions.left);
+				tooltipPositions.right = Math.max(parentRect.width - this.boundary.right, tooltipPositions.right);
 
 				return {
 					leftShift: tooltipPositions.left - prevLeft,
@@ -406,7 +403,7 @@ Polymer-based web component for a D2L tooltip
 			},
 
 			_shouldPositionUsingLeft: function(targetPositions) {
-				return !this._useBoundaries() || targetPositions.xCenter > this.boundaryWidth / 4;
+				return !this._useBoundaries() || targetPositions.horizontalCenter > this.boundaryWidth / 4;
 			},
 
 			_setTooltipStyle: function(tooltipPositions, targetPositions) {
@@ -420,7 +417,7 @@ Polymer-based web component for a D2L tooltip
 
 				this.style.top = tooltipPositions.top + 'px';
 
-				if (this.boundaries) {
+				if (this.boundary) {
 					this.style.maxWidth = this.boundaryWidth + 'px';
 				}
 

--- a/d2l-tooltip.html
+++ b/d2l-tooltip.html
@@ -218,6 +218,11 @@ Polymer-based web component for a D2L tooltip
 					value: false
 				},
 
+				boundaries: {
+					type: Object,
+					value: { left: 0, right: 560 } // TODO: actually have this be passed in
+				},
+
 				_tappedOn: {
 					type: Boolean,
 					value: false
@@ -299,52 +304,113 @@ Polymer-based web component for a D2L tooltip
 					{ xScroll: 0, yScroll: 0 };
 			},
 
+			getOffsets: function(targetRect, thisRect) {
+				return {
+					horizontalCenterOffset: (targetRect.width - thisRect.width) / 2,
+					verticalCenterOffset: (targetRect.height - thisRect.height) / 2
+				};
+			},
+
+			getTargetPositions: function(targetRect, parentRect) {
+				var left = targetRect.left - parentRect.left;
+				var right = parentRect.right - targetRect.right;
+				return {
+					left: left,
+					right: right,
+					xCenter: (right - left) / 2,
+					top: targetRect.top - parentRect.top
+				};
+			},
+
+			getBoundaryWidth: function() {
+				return this.boundaries.right - this.boundaries.left;
+			},
+
+			getTooltipPositions: function(targetPositions, thisRect, targetRect) {
+				var offsets = this.getOffsets(targetRect, thisRect);
+				var scrollVals = this.getScrollVals();
+
+				var horizontalCenterOffset = offsets.horizontalCenterOffset;
+				var verticalCenterOffset = offsets.verticalCenterOffset;
+
+				var tooltipLeft, tooltipTop, tooltipRight, tooltipBottom;
+				switch (this.position) {
+					case 'top':
+						tooltipLeft = targetPositions.left + horizontalCenterOffset;
+						tooltipRight = targetPositions.right + horizontalCenterOffset;
+						tooltipTop = targetPositions.top - thisRect.height - this.offset;
+						break;
+					case 'bottom':
+						tooltipLeft = targetPositions.left + horizontalCenterOffset;
+						tooltipRight = targetPositions.right + horizontalCenterOffset;
+						tooltipTop = targetPositions.top + targetRect.height + this.offset;
+						break;
+					case 'left':
+						tooltipLeft = targetPositions.left - thisRect.width - this.offset;
+						tooltipTop = targetPositions.top + verticalCenterOffset;
+						break;
+					case 'right':
+						tooltipLeft = targetPositions.left + targetRect.width + this.offset;
+						tooltipTop = targetPositions.top + verticalCenterOffset;
+						break;
+				}
+
+				tooltipLeft += scrollVals.xScroll;
+				tooltipTop += scrollVals.yScroll;
+
+				return {
+					top: tooltipTop,
+					left: tooltipLeft,
+					right: tooltipRight,
+					bottom: tooltipBottom
+				};
+			},
+
+			updatetooltipPositionsForBoundary: function(tooltipPositions, parentRect) {
+				tooltipPositions.left = Math.max(this.boundaries.left, tooltipPositions.left);
+				tooltipPositions.right = Math.max(parentRect.width - this.boundaries.right, tooltipPositions.right);
+			},
+
+			setTooltipStyle: function(tooltipPositions, targetPositions) {
+				var boundaryWidth = this.getBoundaryWidth();
+				var boundaryCenter = boundaryWidth / 2;
+				// TODO: take boundaryless into account
+				var leftSideOfBoundary = targetPositions.xCenter > boundaryCenter / 2;
+
+				if (leftSideOfBoundary) {
+					this.style.left = tooltipPositions.left + 'px';
+					this.style.right = 'auto';
+				} else {
+					this.style.left = 'auto';
+					this.style.right = tooltipPositions.right  + 'px';
+				}
+
+				this.style.top = tooltipPositions.top + 'px';
+				this.style.maxWidth = this.getBoundaryWidth() + 'px';
+
+				if (this.tooltipPadding) {
+					this.$.tooltip.style.padding = this.tooltipPadding + 'px';
+				}
+			},
+
 			updatePosition: function() {
 				if (!this.customTarget && (!this._target || !this.offsetParent)) {
 					return;
 				}
 
-				var offset = this.offset;
 				var parentRect = (this.customTarget || this.offsetParent.tagName === 'BODY') ?
 					{ left: 0, top: 0, right: 0, bottom: 0 } :
 					this.offsetParent.getBoundingClientRect();
+
 				var targetRect = this.customTarget ? this.customTarget : this._target.getBoundingClientRect();
 				var thisRect = this.getBoundingClientRect();
 
-				var scrollVals = this.getScrollVals();
-				var xScroll = scrollVals.xScroll;
-				var yScroll = scrollVals.yScroll;
+				var targetPositions = this.getTargetPositions(targetRect, parentRect);
 
-				var horizontalCenterOffset = (targetRect.width - thisRect.width) / 2;
-				var verticalCenterOffset = (targetRect.height - thisRect.height) / 2;
-				var targetLeft = targetRect.left - parentRect.left;
-				var targetTop = targetRect.top - parentRect.top;
+				var tooltipPositions = this.getTooltipPositions(targetPositions, thisRect, targetRect);
+				this.updatetooltipPositionsForBoundary(tooltipPositions, parentRect);
 
-				var tooltipLeft, tooltipTop;
-				switch (this.position) {
-					case 'top':
-						tooltipLeft = targetLeft + horizontalCenterOffset + xScroll;
-						tooltipTop = targetTop - thisRect.height - offset + yScroll;
-						break;
-					case 'bottom':
-						tooltipLeft = targetLeft + horizontalCenterOffset + xScroll;
-						tooltipTop = targetTop + targetRect.height + offset + yScroll;
-						break;
-					case 'left':
-						tooltipLeft = targetLeft - thisRect.width - offset + xScroll;
-						tooltipTop = targetTop + verticalCenterOffset + yScroll;
-						break;
-					case 'right':
-						tooltipLeft = targetLeft + targetRect.width + offset + xScroll;
-						tooltipTop = targetTop + verticalCenterOffset + yScroll;
-						break;
-				}
-
-				this.style.left = tooltipLeft + 'px';
-				this.style.top = tooltipTop + 'px';
-				if (this.tooltipPadding) {
-					this.$.tooltip.style.padding = this.tooltipPadding + 'px';
-				}
+				this.setTooltipStyle(tooltipPositions, targetPositions);
 			},
 
 			get document() {

--- a/d2l-tooltip.html
+++ b/d2l-tooltip.html
@@ -70,7 +70,7 @@ Polymer-based web component for a D2L tooltip
 			:host .d2l-tooltip-triangle {
 				clip: rect(-5px, 21px, 8px, -3px);
 				display: inline-block;
-				left: calc(50% - 8px);
+				left: calc(50% + 8px);
 				position: absolute;
 				top: -7px;
 				z-index: 1;
@@ -365,21 +365,26 @@ Polymer-based web component for a D2L tooltip
 				};
 			},
 
+			_useBoundaries: function() {
+				// Boundaries currently only supported with top/bottom positions
+				return this.boundaries && (this.position === 'top' || this.position === 'bottom');
+			},
+
+			_shouldPositionUsingLeft: function(targetPositions) {
+				return !this._useBoundaries() || targetPositions.xCenter > this.getBoundaryWidth() / 4;
+			},
+
 			updatetooltipPositionsForBoundary: function(tooltipPositions, parentRect) {
-				if (this.boundaries) {
-					tooltipPositions.left = Math.max(this.boundaries.left, tooltipPositions.left);
-					tooltipPositions.right = Math.max(parentRect.width - this.boundaries.right, tooltipPositions.right);
+				if (!this._useBoundaries()) {
+					return;
 				}
+
+				tooltipPositions.left = Math.max(this.boundaries.left, tooltipPositions.left);
+				tooltipPositions.right = Math.max(parentRect.width - this.boundaries.right, tooltipPositions.right);
 			},
 
 			setTooltipStyle: function(tooltipPositions, targetPositions) {
-				var positionUsingLeft =
-					!this.boundaries ||
-					this.position === 'left' || // Positioning from the right currently only supported with top/bottom positions
-					this.position === 'right' ||
-					targetPositions.xCenter > this.getBoundaryWidth() / 4;
-
-				if (positionUsingLeft) {
+				if (this._shouldPositionUsingLeft(targetPositions)) {
 					this.style.left = tooltipPositions.left + 'px';
 					this.style.right = 'auto';
 				} else {
@@ -395,6 +400,20 @@ Polymer-based web component for a D2L tooltip
 
 				if (this.tooltipPadding) {
 					this.$.tooltip.style.padding = this.tooltipPadding + 'px';
+				}
+			},
+
+			setTriangleStyle: function(thisRect, tooltipPositions, targetPositions) {
+				if (!this._useBoundaries()) {
+					return;
+				}
+
+				// ABS?
+				// TODO: CURRENTLY WORKING ON THIS
+				if (this._shouldPositionUsingLeft(targetPositions)) {
+					var leftShift = Math.abs(tooltipPositions.left - Math.max(this.boundaries.left, tooltipPositions.left));
+					var triangleLeft = Math.max((thisRect.width / 2) - leftShift - 8, 8);
+					Polymer.dom(this.$.tooltip).querySelector('.d2l-tooltip-triangle').style.left = triangleLeft + 'px';
 				}
 			},
 
@@ -416,6 +435,7 @@ Polymer-based web component for a D2L tooltip
 				this.updatetooltipPositionsForBoundary(tooltipPositions, parentRect);
 
 				this.setTooltipStyle(tooltipPositions, targetPositions);
+				this.setTriangleStyle(thisRect, tooltipPositions, targetPositions);
 			},
 
 			get document() {

--- a/d2l-tooltip.html
+++ b/d2l-tooltip.html
@@ -70,7 +70,7 @@ Polymer-based web component for a D2L tooltip
 			:host .d2l-tooltip-triangle {
 				clip: rect(-5px, 21px, 8px, -3px);
 				display: inline-block;
-				left: calc(50% + 8px);
+				left: calc(50% - 8px);
 				position: absolute;
 				top: -7px;
 				z-index: 1;
@@ -220,7 +220,7 @@ Polymer-based web component for a D2L tooltip
 
 				boundaries: {
 					type: Object,
-					value: { left: 0, right: 560 } // TODO: actually have this be passed in
+					value: null
 				},
 
 				_tappedOn: {

--- a/d2l-tooltip.html
+++ b/d2l-tooltip.html
@@ -333,7 +333,7 @@ Polymer-based web component for a D2L tooltip
 				var horizontalCenterOffset = offsets.horizontalCenterOffset;
 				var verticalCenterOffset = offsets.verticalCenterOffset;
 
-				var tooltipLeft, tooltipTop, tooltipRight, tooltipBottom;
+				var tooltipLeft, tooltipTop, tooltipRight;
 				switch (this.position) {
 					case 'top':
 						tooltipLeft = targetPositions.left + horizontalCenterOffset;
@@ -361,23 +361,25 @@ Polymer-based web component for a D2L tooltip
 				return {
 					top: tooltipTop,
 					left: tooltipLeft,
-					right: tooltipRight,
-					bottom: tooltipBottom
+					right: tooltipRight
 				};
 			},
 
 			updatetooltipPositionsForBoundary: function(tooltipPositions, parentRect) {
-				tooltipPositions.left = Math.max(this.boundaries.left, tooltipPositions.left);
-				tooltipPositions.right = Math.max(parentRect.width - this.boundaries.right, tooltipPositions.right);
+				if (this.boundaries) {
+					tooltipPositions.left = Math.max(this.boundaries.left, tooltipPositions.left);
+					tooltipPositions.right = Math.max(parentRect.width - this.boundaries.right, tooltipPositions.right);
+				}
 			},
 
 			setTooltipStyle: function(tooltipPositions, targetPositions) {
-				var boundaryWidth = this.getBoundaryWidth();
-				var boundaryCenter = boundaryWidth / 2;
-				// TODO: take boundaryless into account
-				var leftSideOfBoundary = targetPositions.xCenter > boundaryCenter / 2;
+				var positionUsingLeft =
+					!this.boundaries ||
+					this.position === 'left' || // Positioning from the right currently only supported with top/bottom positions
+					this.position === 'right' ||
+					targetPositions.xCenter > this.getBoundaryWidth() / 4;
 
-				if (leftSideOfBoundary) {
+				if (positionUsingLeft) {
 					this.style.left = tooltipPositions.left + 'px';
 					this.style.right = 'auto';
 				} else {
@@ -386,7 +388,10 @@ Polymer-based web component for a D2L tooltip
 				}
 
 				this.style.top = tooltipPositions.top + 'px';
-				this.style.maxWidth = this.getBoundaryWidth() + 'px';
+
+				if (this.boundaries) {
+					this.style.maxWidth = this.getBoundaryWidth() + 'px';
+				}
 
 				if (this.tooltipPadding) {
 					this.$.tooltip.style.padding = this.tooltipPadding + 'px';

--- a/demo/index.html
+++ b/demo/index.html
@@ -32,6 +32,12 @@
 				margin-top: 20px;
 				position: relative;
 				padding: 30px;
+				margin-left: auto;
+				margin-right: auto;
+			}
+
+			.container .box {
+				display: inline-block;
 			}
 
 			.contained {
@@ -92,8 +98,14 @@
 			<br />
 			<div class="container">
 				<div class="contained">
+					filler fillerfiller filler filler filler filler filler
 					<span class="box" id="top-contained">Hover me (top)</span>
-					<d2l-tooltip position="top" showing for="top-contained">This is at the top but should also be too wide for normal</d2l-tooltip>
+					<d2l-tooltip
+						tap-toggle
+						position="bottom"
+						showing
+						for="top-contained"
+					>This is at the s s s s s s s t o pThis is</d2l-tooltip>
 				</div>
 			</div>
 		</div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -68,7 +68,7 @@
 		window.Polymer.dom = 'shadow';
 		*/
 		setTimeout(function() {
-			document.querySelector('.contained d2l-tooltip').boundaries = { left: 0, right: 560 };
+			document.querySelector('.contained d2l-tooltip').boundary = { left: 0, right: 560 };
 		}, 10);
 	</script>
 </head>

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,113 +1,113 @@
 <!doctype html>
 <html>
-  <head>
-    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-    <link rel="import" href="../../d2l-typography/d2l-typography.html">
-    <link rel="import" href="../d2l-tooltip.html">
-		<style>
-			body {
-				margin: 20px;
-			}
 
-			.hover-link-container {
-				padding: 0 120px;
-			}
+<head>
+	<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+	<link rel="import" href="../../d2l-typography/d2l-typography.html">
+	<link rel="import" href="../d2l-tooltip.html">
+	<style>
+		body {
+			margin: 20px;
+		}
 
-			.box {
-				width: 100px;
-				height: 100px;
-				background-color: #e57231;
-				display: inline-block;
-				color: White;
-				display: flex;
-				align-items: center;
-				text-align: center;
-			}
+		.hover-link-container {
+			padding: 0 120px;
+		}
 
-			.container {
-				background: lightgoldenrodyellow;
-				width: 500px;
-				height: 500px;
-				overflow: hidden;
-				margin-top: 20px;
-				position: relative;
-				padding: 30px;
-				margin-left: auto;
-				margin-right: auto;
-			}
+		.box {
+			width: 100px;
+			height: 100px;
+			background-color: #e57231;
+			display: inline-block;
+			color: White;
+			display: flex;
+			align-items: center;
+			text-align: center;
+		}
 
-			.container .box {
-				display: inline-block;
-			}
+		.container {
+			background: lightgoldenrodyellow;
+			width: 500px;
+			height: 500px;
+			overflow: hidden;
+			margin-top: 20px;
+			position: relative;
+			padding: 30px;
+			margin-left: auto;
+			margin-right: auto;
+		}
 
-			.contained {
-				margin-top: 40px;
+		.container .box {
+			display: inline-block;
+		}
+
+		.contained {
+			margin-top: 40px;
+		}
+	</style>
+	<custom-style include="d2l-typography">
+		<style is="custom-style" include="d2l-typography">
+			.mixin-tooltip {
+				--d2l-tooltip-background-color: #ffffff;
+				--d2l-tooltip-border: 1px solid;
+				--d2l-tooltip-border-color: #d3d9e3;
+
+				--d2l-tooltip-mixin: {
+					width: 200px;
+					box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.08);
+					font-family: Lato;
+					line-height: 1;
+					color: #565a5c;
+				}
 			}
 		</style>
-		<custom-style include="d2l-typography">
-			<style is="custom-style" include="d2l-typography">
-        .mixin-tooltip {
-          --d2l-tooltip-background-color: #ffffff;
-          --d2l-tooltip-border: 1px solid;
-          --d2l-tooltip-border-color:  #d3d9e3;
+	</custom-style>
+	<script>
+		/*
+		window.Polymer = window.Polymer || {};
+		window.Polymer.dom = 'shadow';
+		*/
+		setTimeout(function() {
+			document.querySelector('.contained d2l-tooltip').boundaries = { left: 0, right: 560 };
+		}, 10);
+	</script>
+</head>
 
-          --d2l-tooltip-mixin: {
-            width: 200px;
-            box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.08);
-            font-family: Lato;
-			line-height: 1;
-            color: #565a5c;
-          }
-        }
-      </style>
-		</custom-style>
-    <script>
-      /*
-      window.Polymer = window.Polymer || {};
-      window.Polymer.dom = 'shadow';
-      */
-    </script>
-  </head>
-  <body class="d2l-typography">
-		<div class="hover-link-container">
-			<span class="box" id="bottom">Hover me (bottom)</span>
-			<d2l-tooltip position="bottom" for="bottom">Bottom</d2l-tooltip>
-			<br />
-			<span class="box" id="top">Hover me (top)</span>
-			<d2l-tooltip position="top" for="top">Top</d2l-tooltip>
-			<br />
-			<span class="box" id="left">Hover me (left)</span>
-			<d2l-tooltip position="left" for="left">Left</d2l-tooltip>
-			<br />
-			<span class="box" id="right">Hover me (right)</span>
-			<d2l-tooltip position="right" for="right">Right</d2l-tooltip>
-			<br />
-			<span class="box" id="mixin">Mixin Tooltip (right)</span>
-			<d2l-tooltip class="mixin-tooltip" position="right" for="mixin">
-				Use custom parameters to style the tooltip.
-			</d2l-tooltip>
-			<br />
-			<span class="box" id="right-tap-toggle" tabindex="0">Tap me (right)</span>
-			<d2l-tooltip id="tap-toggle-tooltip" position="right" for="right-tap-toggle" tap-toggle>Right Tap Toggle</d2l-tooltip>
-			<br />
-			<button id="aria-button">Focus me for aria-describedby</button>
-			<d2l-tooltip id="buttontooltip" position="right" for="aria-button">This is a button</d2l-tooltip>
-			<br />
-			<button id="aria-button2">Focus me, too</button>
-			<d2l-tooltip position="right" for="aria-button2">I have a generated id</d2l-tooltip>
-			<br />
-			<div class="container">
-				<div class="contained">
-					filler fillerfiller filler filler filler filler filler
-					<span class="box" id="top-contained">Hover me (top)</span>
-					<d2l-tooltip
-						tap-toggle
-						position="top"
-						showing
-						for="top-contained"
-					>This is this.position === 'left' || this.position === 'right'at the s s s s s s s t o pThis is</d2l-tooltip>
-				</div>
+<body class="d2l-typography">
+	<div class="hover-link-container">
+		<span class="box" id="bottom">Hover me (bottom)</span>
+		<d2l-tooltip position="bottom" for="bottom">Bottom</d2l-tooltip>
+		<br />
+		<span class="box" id="top">Hover me (top)</span>
+		<d2l-tooltip position="top" for="top">Top</d2l-tooltip>
+		<br />
+		<span class="box" id="left">Hover me (left)</span>
+		<d2l-tooltip position="left" for="left">Left</d2l-tooltip>
+		<br />
+		<span class="box" id="right">Hover me (right)</span>
+		<d2l-tooltip position="right" for="right">Right</d2l-tooltip>
+		<br />
+		<span class="box" id="mixin">Mixin Tooltip (right)</span>
+		<d2l-tooltip class="mixin-tooltip" position="right" for="mixin">
+			Use custom parameters to style the tooltip.
+		</d2l-tooltip>
+		<br />
+		<span class="box" id="right-tap-toggle" tabindex="0">Tap me (right)</span>
+		<d2l-tooltip id="tap-toggle-tooltip" position="right" for="right-tap-toggle" tap-toggle>Right Tap Toggle</d2l-tooltip>
+		<br />
+		<button id="aria-button">Focus me for aria-describedby</button>
+		<d2l-tooltip id="buttontooltip" position="right" for="aria-button">This is a button</d2l-tooltip>
+		<br />
+		<button id="aria-button2">Focus me, too</button>
+		<d2l-tooltip position="right" for="aria-button2">I have a generated id</d2l-tooltip>
+		<br />
+		<div class="container">
+			<div class="contained">
+				<span class="box" id="top-contained">Hover me, I have boundaries!</span>
+				<d2l-tooltip tap-toggle position="top" for="top-contained">This is a tooltip positioned inside a box with "overflow: hidden"</d2l-tooltip>
 			</div>
 		</div>
-	</body>
+	</div>
+</body>
+
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -102,10 +102,10 @@
 					<span class="box" id="top-contained">Hover me (top)</span>
 					<d2l-tooltip
 						tap-toggle
-						position="bottom"
+						position="top"
 						showing
 						for="top-contained"
-					>This is at the s s s s s s s t o pThis is</d2l-tooltip>
+					>This is this.position === 'left' || this.position === 'right'at the s s s s s s s t o pThis is</d2l-tooltip>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
This looks like a lot more code than it is since I found that all the placement code was easiest to reason about after being broken into smaller functions

That aside, what this PR essentially does is:
- Allow the user to set a boundaries property which constrains the area that a top/bottom tooltip can stretch to
- Shift the tooltip triangle to make up for the shift due to boundary 
- If the tooltip target is on the right side of the boundary, grow the tooltip from the right (to avoid any text wrapping before it needs to when it reaches the end of a relative container), otherwise grow the tooltip from the left.
