### PR TITLE
update os x version to 13

### DIFF
--- a/wct.conf.json
+++ b/wct.conf.json
@@ -10,17 +10,17 @@
       "browsers": [
         {
           "browserName": "chrome",
-          "platform": "OS X 10.12",
+          "platform": "OS X 10.13",
           "version": ""
         },
         {
           "browserName": "firefox",
-          "platform": "OS X 10.12",
+          "platform": "OS X 10.13",
           "version": ""
         },
         {
           "browserName": "safari",
-          "platform": "OS X 10.12",
+          "platform": "OS X 10.13",
           "version": ""
         },
         {


### PR DESCRIPTION
the test failures are not new (I think they are because of a problem with using focus during tests?), but I believe this stops safari from erroring