### PR TITLE
Add force-show attribute to enable programmatic display of tooltip

### DIFF
--- a/d2l-tooltip.html
+++ b/d2l-tooltip.html
@@ -43,11 +43,16 @@ Polymer-based web component for a D2L tooltip
 				@apply --d2l-tooltip-mixin; /* needs to be down here to override any of the properties above */
 			}
 
-			:host([showing]) {
+			:host([showing]), :host([force-show]) {
 				display: inline-block;
 			}
 
-			:host([showing]) {
+			:host([force-show]) {
+				-webkit-animation: d2l-tooltip-bottom-animation 200ms ease;
+				animation: d2l-tooltip-bottom-animation 200ms ease;
+			}
+
+			:host([showing]):not([force-show]) {
 				-webkit-animation: d2l-tooltip-bottom-animation 200ms ease;
 				animation: d2l-tooltip-bottom-animation 200ms ease;
 			}
@@ -227,7 +232,14 @@ Polymer-based web component for a D2L tooltip
 				_tappedOn: {
 					type: Boolean,
 					value: false
-				}
+				},
+
+				forceShow: {
+					type: Boolean,
+					value: false,
+					reflectToAttribute: true,
+					observer: 'updateForceShow'
+				},
 			},
 
 			listeners: {
@@ -323,6 +335,15 @@ Polymer-based web component for a D2L tooltip
 
 				this._setTooltipStyle(tooltipPositions, targetPositions);
 				this._setTriangleStyle(thisRect, tooltipPositions, targetPositions, boundaryShifts);
+			},
+
+			updateForceShow: function(forceShow) {
+				if (forceShow) {
+					this.async(function() { this.updatePosition(); }.bind(this));
+				}
+				if (!forceShow) {
+					this.hide();
+				}
 			},
 
 			_getScrollVals: function() {
@@ -470,7 +491,7 @@ Polymer-based web component for a D2L tooltip
 			},
 
 			_addListeners: function() {
-				if (this._target) {
+				if (this._target && !this.forceShow) {
 					this.listen(this._target, 'mouseenter', 'show');
 					this.listen(this._target, 'focus', 'show');
 					this.listen(this._target, 'mouseleave', 'hide');


### PR DESCRIPTION
In our work for the new rubric create component, we are using tooltips to display errors on input fields.
However, we found that the existing behavior of only showing the tooltip on mouseover and when selected was not aggressive enough (users were overlooking the errors), and so design asked for the tooltips to be shown permanently under certain circumstances. The behavior dictating when exactly to show them can be implemented within the rubric component, but for that we need a way to programmatically display the tooltips.
For this, I've added the optional attribute `force-show` which causes the tooltip to display. It also disables the event-based handling, since this is intended to be as dumb as possible: if `force-show` is set, then display the tooltip - no questions asked.