### PR TITLE
US105979 - Firefox isn't rendering the tooltip in the correct location

### DIFF
--- a/d2l-tooltip.js
+++ b/d2l-tooltip.js
@@ -17,6 +17,7 @@ import 'd2l-typography/d2l-typography-shared-styles.js';
 import { IronResizableBehavior } from '@polymer/iron-resizable-behavior/iron-resizable-behavior.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';
+import { getOffsetParent } from './offset-parent.js';
 const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="d2l-tooltip">
@@ -174,7 +175,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-tooltip">
 			<slot></slot>
 		</div>
 	</template>
-	
+
 </dom-module>`;
 
 document.head.appendChild($_documentContainer.content);
@@ -324,20 +325,21 @@ Polymer({
 	},
 
 	updatePosition: function() {
-		if (!this.customTarget && (!this._target || !this.offsetParent)) {
+		const offsetParent = getOffsetParent(this);
+		if (!this.customTarget && (!this._target || !offsetParent)) {
 			return;
 		}
 
 		var targetRect = this.customTarget ? this.customTarget : this._target.getBoundingClientRect();
 		var thisRect = this.getBoundingClientRect();
-		var parentRect = (this.customTarget || this.offsetParent.tagName === 'BODY') ?
+		var parentRect = (this.customTarget || offsetParent.tagName === 'BODY') ?
 			{ left: 0, top: 0, right: 0, bottom: 0 } :
-			this.offsetParent.getBoundingClientRect();
+			offsetParent.getBoundingClientRect();
 
 		var targetPositions = this._getTargetPositions(targetRect, parentRect);
 		var tooltipPositions = this._getTooltipPositions(targetPositions, thisRect, targetRect);
 
-		var boundaryParent = this.offsetParent ? this.offsetParent.getBoundingClientRect() : { left: 0, top: 0, right: 0, bottom: 0 };
+		var boundaryParent = offsetParent ? offsetParent.getBoundingClientRect() : { left: 0, top: 0, right: 0, bottom: 0 };
 		var boundaryShifts = this._updateTooltipPositionsForBoundary(tooltipPositions, boundaryParent);
 
 		this._setTooltipStyle(tooltipPositions, targetPositions);
@@ -353,8 +355,9 @@ Polymer({
 	},
 
 	_getScrollVals: function() {
-		if (this.offsetParent) {
-			var parentStyle = window.getComputedStyle(this.offsetParent);
+		const offsetParent = getOffsetParent(this);
+		if (offsetParent) {
+			var parentStyle = window.getComputedStyle(offsetParent);
 			return (parentStyle && parentStyle.getPropertyValue('position') === 'static') ?
 				{ xScroll: window.pageXOffset, yScroll: window.pageYOffset } :
 				{ xScroll: 0, yScroll: 0 };

--- a/offset-parent.js
+++ b/offset-parent.js
@@ -2,17 +2,17 @@
 // Implementation of draft proposal: https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetparent
 // Original implementation: https://www.w3.org/TR/cssom-view/#dom-htmlelement-offsetparent
 const getOffsetParent = function(ele) {
+	// Fallback to built-in
+	if (!window.ShadowRoot) {
+		return ele.offsetParent;
+	}
+
 	if (
 		!getParent(ele) ||
 		ele.tagName === 'BODY' ||
 		window.getComputedStyle(ele).position === 'fixed'
 	) {
 		return null;
-	}
-
-	// Fallback to built-in
-	if (!window.ShadowRoot) {
-		return ele.offsetParent;
 	}
 
 	let currentEle = getParent(ele);
@@ -32,7 +32,6 @@ const getOffsetParent = function(ele) {
 
 	return null;
 };
-
 
 const getParent = function(ele) {
 	// Check if slotted

--- a/offset-parent.js
+++ b/offset-parent.js
@@ -21,7 +21,7 @@ const getOffsetParent = function(ele) {
 		const tagName = currentEle.tagName;
 
 		if (
-			position !== 'static' ||
+			(position && position !== 'static') ||
 			tagName === 'BODY' ||
 			position === 'static' && (tagName === 'TD' || tagName === 'TH' || tagName === 'TABLE')
 		) {

--- a/offset-parent.js
+++ b/offset-parent.js
@@ -1,0 +1,51 @@
+// Custom implementation of HTMLElement.offsetParent, specifically for d2l-tooltip, to detect shadow ancestors in Firefox
+// Implementation of draft proposal: https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetparent
+// Original implementation: https://www.w3.org/TR/cssom-view/#dom-htmlelement-offsetparent
+const getOffsetParent = function(ele) {
+	if (
+		!getParent(ele) ||
+		ele.tagName === 'BODY' ||
+		window.getComputedStyle(ele).position === 'fixed'
+	) {
+		return null;
+	}
+
+	// Fallback to built-in
+	if (!window.ShadowRoot) {
+		return ele.offsetParent;
+	}
+
+	let currentEle = getParent(ele);
+	while (currentEle) {
+		const position = window.getComputedStyle(currentEle).position;
+		const tagName = currentEle.tagName;
+
+		if (
+			position !== 'static' ||
+			tagName === 'BODY' ||
+			position === 'static' && (tagName === 'TD' || tagName === 'TH' || tagName === 'TABLE')
+		) {
+			return currentEle;
+		}
+		currentEle = getParent(currentEle);
+	}
+
+	return null;
+};
+
+
+const getParent = function(ele) {
+	// Check if slotted
+	if (ele.assignedSlot) {
+		return ele.assignedSlot.parentElement;
+	}
+
+	// Check if at top of shadow dom
+	if (!ele.parentElement && ele.parentNode instanceof ShadowRoot) {
+		return ele.parentNode.host;
+	}
+
+	return ele.parentElement;
+};
+
+export { getOffsetParent };

--- a/test/index.html
+++ b/test/index.html
@@ -9,7 +9,9 @@
 		<script>
 			WCT.loadSuites([
 				'd2l-tooltip.html?wc-shadydom=true&wc-ce=true',
-				'd2l-tooltip.html?dom=shadow'
+				'd2l-tooltip.html?dom=shadow',
+				'offset-parent.html?wc-shadydom=true&wc-ce=true',
+				'offset-parent.html?dom=shadow'
 			]);
 		</script>
 	</body>

--- a/test/offset-parent.html
+++ b/test/offset-parent.html
@@ -1,0 +1,232 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>offset-parent test</title>
+		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+		<script src="../../wct-browser-legacy/browser.js"></script>
+		<script type="module" src="../../@polymer/iron-test-helpers/mock-interactions.js"></script>
+		<style>
+			.relative {
+				position: relative;
+			}
+			.static {
+				position: static;
+			}
+		</style>
+	</head>
+	<body>
+		<test-fixture id="direct-parent">
+			<template><div>
+					<div class="relative expected">
+						<div class="child"></div>
+					</div>
+			</div></template>
+		</test-fixture>
+
+		<test-fixture id="indirect-parent">
+			<template><div>
+					<div class="relative expected">
+						<div>
+							<div class="child"></div>
+						</div>
+					</div>
+			</div></template>
+		</test-fixture>
+
+		<test-fixture id="td">
+			<template><div>
+				<table>
+					<td class="static expected">
+						<div class="child"></div>
+					</td>
+				</table>
+			</div></template>
+		</test-fixture>
+
+		<test-fixture id="th">
+			<template><div>
+				<table>
+					<th class="static expected">
+						<div class="child"></div>
+					</th>
+				</table>
+			</div></template>
+		</test-fixture>
+
+		<test-fixture id="table">
+			<template><div>
+				<table class="static expected">
+					<tbody class="child"></tbody>
+				</table>
+			</div></template>
+		</test-fixture>
+
+		<test-fixture id="wrapper-simple">
+			<template><div>
+				<test-wrapper wrapper-id="expected">
+					<div class="child"></div>
+				</test-wrapper>
+			</div></template>
+		</test-fixture>
+
+		<test-fixture id="wrapper-inside">
+			<template><div>
+				<test-wrapper>
+					<div class="relative expected">
+						<div class="child"></div>
+					<div>
+				</test-wrapper>
+			</div></template>
+		</test-fixture>
+
+		<test-fixture id="wrapper-nested">
+			<template><div>
+				<test-wrapper>
+					<test-wrapper wrapper-id="expected">
+						<div class="child"></div>
+					</test-wrapper>
+				</test-wrapper>
+			</div></template>
+		</test-fixture>
+
+		<test-fixture id="wrapper-passthrough">
+			<template><div>
+				<div class="relative expected">
+					<test-wrapper>
+						<div class="child"></div>
+					</test-wrapper>
+				<div>
+			</div></template>
+		</test-fixture>
+
+		<test-fixture id="wrapper-is-parent">
+			<template><div>
+				<test-wrapper class="relative expected">
+					<div class="child"></div>
+				</test-wrapper>
+			</div></template>
+		</test-fixture>
+
+		<test-fixture id="nested-wrapper-is-parent">
+			<template><div>
+				<test-wrapper class="relative expected">
+					<test-wrapper>
+						<div class="child"></div>
+					</test-wrapper>
+				</test-wrapper>
+			</div></template>
+		</test-fixture>
+
+		<div id="fixed" style="position: fixed;">
+		</div>
+
+		<div id="bodyIsParent">
+		</div>
+
+		<script type="module">
+import { getOffsetParent } from '../offset-parent.js';
+describe('offset-parent', function() {
+	[
+		'direct-parent',
+		'indirect-parent',
+		'td',
+		'th',
+		'table',
+		'wrapper-inside',
+		'wrapper-passthrough',
+		'wrapper-is-parent',
+		'nested-wrapper-is-parent'
+	].forEach(fixtureName => {
+		it(fixtureName, function() {
+			const fixt = fixture(fixtureName);
+			const child = fixt.querySelector('.child');
+			const expected = fixt.querySelector('.expected');
+			expect(getOffsetParent(child)).to.equal(expected);
+		});
+	});
+
+	it('wrapper-simple', function() {
+		const fixt = fixture('wrapper-simple');
+		const child = fixt.querySelector('.child');
+		expect(getOffsetParent(child).id).to.equal('expected');
+	});
+
+	it('wrapper-nested', function() {
+		const fixt = fixture('wrapper-nested');
+		const child = fixt.querySelector('.child');
+		expect(getOffsetParent(child).id).to.equal('expected');
+	});
+
+	it('fallback-when-shadowroot-undefined', function() {
+		const tempShadowRoot = window.ShadowRoot;
+		window.ShadowRoot = false;
+		const child = {
+			offsetParent: 'this is the offsetParent'
+		};
+		expect(getOffsetParent(child)).to.equal(child.offsetParent);
+		window.ShadowRoot = tempShadowRoot;
+	});
+
+	it('body', function() {
+		const body = document.querySelector('body');
+		expect(getOffsetParent(body)).to.equal(null);
+	});
+
+	it('orphan', function() {
+		const child = document.createElement('div');
+		expect(getOffsetParent(child)).to.equal(null);
+	});
+
+	it('orphan-with-extra-steps', function() {
+		const grandparent = document.createElement('div');
+		const parent = document.createElement('div');
+		const child = document.createElement('div');
+		grandparent.appendChild(parent);
+		parent.appendChild(child);
+		expect(getOffsetParent(child)).to.equal(null);
+	});
+
+	it('fixed', function() {
+		const fixed = document.querySelector('#fixed');
+		expect(getOffsetParent(fixed)).to.equal(null);
+	});
+
+	it('body-is-parent', function() {
+		const fixed = document.querySelector('#bodyIsParent');
+		const body = document.querySelector('body');
+		expect(getOffsetParent(fixed)).to.equal(body);
+	});
+});
+		</script>
+		<script type="module">
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+
+class TestWrapper extends PolymerElement {
+	static get template() {
+		return html`
+			<style>
+				#expected {
+					position: relative;
+				}
+			</style>
+			<div id=[[wrapperId]]>
+				<slot></slot>
+			</div>
+		`;
+	}
+	static get properties() {
+		return {
+			wrapperId: {
+				type: String,
+				value: 'notExpected'
+			}
+		};
+	}
+}
+
+window.customElements.define('test-wrapper', TestWrapper);
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
Putting this up now to get some early feedback. Tests to come (lots and lots of tests because this change makes me nervous).

*Problem:* Firefox wasn't rendering our tooltips in the correct location. Upon investigation, I noticed that Chrome 73 and Firefox 66 were returning different values for [`HTMLElement.offsetParent`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent).

I created [this repo](https://git.dev.d2l/users/abedley/repos/ff-offsetparent-bug/browse) to demonstrate the issue.

Digging into the issue further, Chrome seemed to traverse ancestors through the shadow dom, whereas Firefox was only traversing the light dom.

So who's correct? Well [the spec](https://www.w3.org/TR/cssom-view/#dom-htmlelement-offsetparent) doesn't even reference the shadow dom at all. So you could argue Firefox is compliant. However there is [a draft proposal](https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetparent) which specifically addresses the shadow dom which Chrome seems to be following. Just for fun I checked Edge and it agreed with Chrome.

*Solution:* In our case, it's much more convenient if Chrome is correct. So I implemented the Chrome version of `offsetParent`