### PR TITLE
Allow FocusLock to be disabled.

### DIFF
--- a/d2l-tooltip.js
+++ b/d2l-tooltip.js
@@ -237,6 +237,11 @@ Polymer({
 			value: null
 		},
 
+		disableFocusLock: {
+			type: Boolean,
+			value: false
+		},
+
 		_tappedOn: {
 			type: Boolean,
 			value: false
@@ -351,8 +356,10 @@ Polymer({
 		this._setTriangleStyle(thisRect, tooltipPositions, targetPositions, boundaryShifts);
 	},
 
-	_onFocus: function() {
-		this._focusLock = true;
+	_onFocus: function () {
+		if (!this.disableFocusLock) {
+			this._focusLock = true;
+		}
 		this.show();
 	},
 

--- a/d2l-tooltip.js
+++ b/d2l-tooltip.js
@@ -356,7 +356,7 @@ Polymer({
 		this._setTriangleStyle(thisRect, tooltipPositions, targetPositions, boundaryShifts);
 	},
 
-	_onFocus: function () {
+	_onFocus: function() {
 		if (!this.disableFocusLock) {
 			this._focusLock = true;
 		}


### PR DESCRIPTION
The recent fix to lock focus gives us undesired behavior, see screencasts below. This PR allows user to disable this functionality.

This is what we have:
![tooltip-After](https://user-images.githubusercontent.com/1471557/58208125-f80d3880-7c98-11e9-99cf-27bfe8997e16.gif)

This is what we want:
![tooltip-Before](https://user-images.githubusercontent.com/1471557/58208146-04919100-7c99-11e9-9612-9b701de744ed.gif)
