### PR TITLE
add configurable tooltip-delay attribute

### DIFF
--- a/d2l-tooltip.js
+++ b/d2l-tooltip.js
@@ -336,7 +336,7 @@ Polymer({
 				this.hide();
 			});
 			this.updatePosition();
-		}, this.tooltipDelay);
+		}, this.delay);
 	},
 
 	hide: function() {

--- a/d2l-tooltip.js
+++ b/d2l-tooltip.js
@@ -258,13 +258,12 @@ Polymer({
 			reflectToAttribute: true,
 			observer: '_updateForceShow'
 		},
-		tooltipDelay: {
+		delay: {
 			type: Number,
-			value: 0,
-			reflectToAttribute: true
+			value: 0
 		},
 		_pendingToolTip: {
-			type: Object
+			type: Number
 		}
 
 	},

--- a/d2l-tooltip.js
+++ b/d2l-tooltip.js
@@ -257,7 +257,16 @@ Polymer({
 			value: false,
 			reflectToAttribute: true,
 			observer: '_updateForceShow'
+		},
+		tooltipDelay: {
+			type: Number,
+			value: 0,
+			reflectToAttribute: true
+		},
+		_pendingToolTip: {
+			type: Object
 		}
+
 	},
 
 	listeners: {
@@ -298,7 +307,6 @@ Polymer({
 		if (this.showing) {
 			return;
 		}
-
 		/* There seems to be an issue in Polymer v2, within Chrome, while using the wc-shadydom=true flag
 		   which results in the textContent property not containing the element text. Instead the only
 		   place it can be found is on this.innerText. */
@@ -318,23 +326,25 @@ Polymer({
 				return;
 			}
 		}
-
-		this.showing = true;
-		this.dispatchEvent(new CustomEvent(
-			'd2l-tooltip-show', { bubbles: true, composed: true }
-		));
-		this._dismissibleId = setDismissible(() => {
-			this._tappedOn = false;
-			this.hide();
-		});
-		this.updatePosition();
+		clearTimeout(this._pendingToolTip);
+		this._pendingToolTip = setTimeout( ()=> {
+			this.showing = true;
+			this.dispatchEvent(new CustomEvent(
+				'd2l-tooltip-show', { bubbles: true, composed: true }
+			));
+			this._dismissibleId = setDismissible(() => {
+				this._tappedOn = false;
+				this.hide();
+			});
+			this.updatePosition();
+		}, this.tooltipDelay);
 	},
 
 	hide: function() {
+		clearTimeout(this._pendingToolTip);
 		if (this._tappedOn || !this.showing || this._focusLock) {
 			return;
 		}
-
 		this.showing = false;
 		this.dispatchEvent(new CustomEvent(
 			'd2l-tooltip-hide', { bubbles: true, composed: true }

--- a/d2l-tooltip.js
+++ b/d2l-tooltip.js
@@ -295,6 +295,7 @@ Polymer({
 	},
 
 	detached: function() {
+		clearTimeout(this._pendingToolTip);
 		this._removeListeners();
 		if (this._dismissibleId) {
 			clearDismissible(this._dismissibleId);

--- a/d2l-tooltip.js
+++ b/d2l-tooltip.js
@@ -327,7 +327,7 @@ Polymer({
 			}
 		}
 		clearTimeout(this._pendingToolTip);
-		this._pendingToolTip = setTimeout( ()=> {
+		this._pendingToolTip = setTimeout(()=> {
 			this.showing = true;
 			this.dispatchEvent(new CustomEvent(
 				'd2l-tooltip-show', { bubbles: true, composed: true }

--- a/d2l-tooltip.js
+++ b/d2l-tooltip.js
@@ -326,7 +326,7 @@ Polymer({
 			}
 		}
 		clearTimeout(this._pendingToolTip);
-		this._pendingToolTip = setTimeout(()=> {
+		this._pendingToolTip = setTimeout(() => {
 			this.showing = true;
 			this.dispatchEvent(new CustomEvent(
 				'd2l-tooltip-show', { bubbles: true, composed: true }

--- a/demo/index.html
+++ b/demo/index.html
@@ -121,13 +121,13 @@ $_documentContainer.innerHTML = `<div class="hover-link-container">
 		<d2l-tooltip position="right" for="force" force-show="">Always visible</d2l-tooltip>
 		<br>
 		<span class="box" id="delay" tabindex="0" >Hover me (delayed bottom)</span>
-		<d2l-tooltip position="bottom" for="delay" tooltip-delay="1000">I was delayed, I only show if the focus is still on my for</d2l-tooltip>
+		<d2l-tooltip position="bottom" for="delay" delay="1000">I was delayed, I only show if the focus is still on my for</d2l-tooltip>
 		<br>
 		<span class="box" id="right-tap-toggle" tabindex="0">Tap me (right)</span>
 		<d2l-tooltip id="tap-toggle-tooltip" position="right" for="right-tap-toggle" tap-toggle="">Right Tap Toggle</d2l-tooltip>
 		<br>
 		<span class="box" id="right-tap-toggle-delayed" tabindex="0">Tap me (right delayed)</span>
-		<d2l-tooltip id="tap-toggle-tooltip-delayed" position="right" for="right-tap-toggle-delayed" tap-toggle="" tooltip-delay="1000">Right Tap Toggle delayed</d2l-tooltip>
+		<d2l-tooltip id="tap-toggle-tooltip-delayed" position="right" for="right-tap-toggle-delayed" tap-toggle="" delay="1000">Right Tap Toggle delayed</d2l-tooltip>
 		<br>
 		<button id="aria-button">Focus me for aria-describedby</button>
 		<d2l-tooltip id="buttontooltip" position="right" for="aria-button">This is a button</d2l-tooltip>

--- a/demo/index.html
+++ b/demo/index.html
@@ -120,8 +120,14 @@ $_documentContainer.innerHTML = `<div class="hover-link-container">
 		<span class="box" id="force">My tooltip is always visible</span>
 		<d2l-tooltip position="right" for="force" force-show="">Always visible</d2l-tooltip>
 		<br>
+		<span class="box" id="delay" tabindex="0" >Hover me (delayed bottom)</span>
+		<d2l-tooltip position="bottom" for="delay" tooltip-delay="1000">I was delayed, I only show if the focus is still on my for</d2l-tooltip>
+		<br>
 		<span class="box" id="right-tap-toggle" tabindex="0">Tap me (right)</span>
 		<d2l-tooltip id="tap-toggle-tooltip" position="right" for="right-tap-toggle" tap-toggle="">Right Tap Toggle</d2l-tooltip>
+		<br>
+		<span class="box" id="right-tap-toggle-delayed" tabindex="0">Tap me (right delayed)</span>
+		<d2l-tooltip id="tap-toggle-tooltip-delayed" position="right" for="right-tap-toggle-delayed" tap-toggle="" tooltip-delay="1000">Right Tap Toggle delayed</d2l-tooltip>
 		<br>
 		<button id="aria-button">Focus me for aria-describedby</button>
 		<d2l-tooltip id="buttontooltip" position="right" for="aria-button">This is a button</d2l-tooltip>

--- a/test/d2l-tooltip.html
+++ b/test/d2l-tooltip.html
@@ -23,7 +23,7 @@
 			<template>
 				<div>
 					<span id="basic-span-delay" tabindex="-1">Hover me for tips</span>
-					<d2l-tooltip tooltip-delay="500" for="basic-span-delay">If I got a problem then a problem's got a problem.</d2l-tooltip>
+					<d2l-tooltip delay="3000" for="basic-span-delay">If I got a problem then a problem's got a problem.</d2l-tooltip>
 					<a href="https://www.google.com">some link</a>
 				</div>
 			</template>
@@ -103,62 +103,58 @@ describe('d2l-tooltip', function() {
 
 	});
 
-	describe('basic-delayed', function() {
-
-		beforeEach(function(done) {
+	describe('basic delayed', function() {
+		beforeEach(function(){
+			this.clock = sinon.useFakeTimers();
 			tooltipFixture = fixture('basic-delay');
 			tooltip = tooltipFixture.querySelector('d2l-tooltip');
-			flush(done);
+
+		});
+		afterEach(function(){
+			this.clock.restore();
 		});
 
-		it('should instantiate the element', function() {
-			expect(tooltip.is).to.equal('d2l-tooltip');
-		});
-
-		it('should trigger the show event when target is focused', function(done) {
+		it('should not render if focus is lost before tooltip is rendered', function(done) {
 			tooltipFixture.addEventListener('d2l-tooltip-show', function() {
-				requestAnimationFrame(function() {
-					expect(tooltip.hasAttribute('showing')).to.equal(true);
-					done();
-				});
+				expect.fail('tooltip should not have been shown');
 			});
 			tooltipFixture.querySelector('#basic-span-delay').focus();
-		});
-
-		it('should not trigger the hide event from mouseleave when target is focused', function(done) {
-			const eventTimeout = setTimeout(function() {
-				expect(tooltip.hasAttribute('showing')).to.equal(true);
+			this.clock.tick(500);
+			tooltipFixture.querySelector('#basic-span-delay').blur();
+			this.clock.tick(5000);
+			requestAnimationFrame(function() {
+				expect(tooltip.hasAttribute('showing')).to.be.equal(false);
 				done();
-			}, 1000);
-			tooltipFixture.addEventListener('d2l-tooltip-show', function() {
-				requestAnimationFrame(function() {
-					const mouseleaveEvent = new Event('mouseleave');
-					tooltipFixture.querySelector('span').dispatchEvent(mouseleaveEvent);
-				});
 			});
-			tooltipFixture.addEventListener('d2l-tooltip-hide', function() {
-				clearTimeout(eventTimeout);
-				done('Tooltip hide event was triggered!');
-			});
-			tooltipFixture.querySelector('span').focus();
 		});
+		it('should not render if focus is lost before tooltip is rendered', function(done) {
+			tooltipFixture.addEventListener('d2l-tooltip-show', function() {
+				expect.fail('tooltip should not have been shown');
+			});
+			for (var i=0; i < 5; i++) {
+				tooltipFixture.querySelector('#basic-span-delay').focus();
+				this.clock.tick(500);
+				tooltipFixture.querySelector('#basic-span-delay').blur();
+			}
 
-		it('should trigger the hide event from blur when target is focused', function(done) {
+			requestAnimationFrame(function() {
+				expect(tooltip.hasAttribute('showing')).to.be.equal(false);
+				done();
+			});
+		});
+		it('should  render if focus is maintained for delay before tooltip is rendered', function(done) {
+
 			tooltipFixture.addEventListener('d2l-tooltip-show', function() {
 				requestAnimationFrame(function() {
-					const blurEvent = new Event('blur');
-					tooltipFixture.querySelector('span').dispatchEvent(blurEvent);
-				});
-			});
-			tooltipFixture.addEventListener('d2l-tooltip-hide', function() {
-				requestAnimationFrame(function() {
-					expect(tooltip.hasAttribute('showing')).to.equal(false);
+					expect(tooltip.hasAttribute('showing')).to.be.equal(true);
 					done();
 				});
 			});
-			tooltipFixture.querySelector('span').focus();
-		});
 
+			tooltipFixture.querySelector('#basic-span-delay').focus();
+			this.clock.tick(5000);
+
+		});
 	});
 	describe('force-show', function() {
 

--- a/test/d2l-tooltip.html
+++ b/test/d2l-tooltip.html
@@ -19,6 +19,15 @@
 				</div>
 			</template>
 		</test-fixture>
+		<test-fixture id="basic-delay">
+			<template>
+				<div>
+					<span id="basic-span-delay" tabindex="-1">Hover me for tips</span>
+					<d2l-tooltip tooltip-delay="500" for="basic-span-delay">If I got a problem then a problem's got a problem.</d2l-tooltip>
+					<a href="https://www.google.com">some link</a>
+				</div>
+			</template>
+		</test-fixture>
 		<test-fixture id="force-show">
 			<template>
 				<div>
@@ -56,6 +65,64 @@ describe('d2l-tooltip', function() {
 				});
 			});
 			tooltipFixture.querySelector('#basic-span').focus();
+		});
+
+		it('should not trigger the hide event from mouseleave when target is focused', function(done) {
+			const eventTimeout = setTimeout(function() {
+				expect(tooltip.hasAttribute('showing')).to.equal(true);
+				done();
+			}, 1000);
+			tooltipFixture.addEventListener('d2l-tooltip-show', function() {
+				requestAnimationFrame(function() {
+					const mouseleaveEvent = new Event('mouseleave');
+					tooltipFixture.querySelector('span').dispatchEvent(mouseleaveEvent);
+				});
+			});
+			tooltipFixture.addEventListener('d2l-tooltip-hide', function() {
+				clearTimeout(eventTimeout);
+				done('Tooltip hide event was triggered!');
+			});
+			tooltipFixture.querySelector('span').focus();
+		});
+
+		it('should trigger the hide event from blur when target is focused', function(done) {
+			tooltipFixture.addEventListener('d2l-tooltip-show', function() {
+				requestAnimationFrame(function() {
+					const blurEvent = new Event('blur');
+					tooltipFixture.querySelector('span').dispatchEvent(blurEvent);
+				});
+			});
+			tooltipFixture.addEventListener('d2l-tooltip-hide', function() {
+				requestAnimationFrame(function() {
+					expect(tooltip.hasAttribute('showing')).to.equal(false);
+					done();
+				});
+			});
+			tooltipFixture.querySelector('span').focus();
+		});
+
+	});
+
+	describe('basic-delayed', function() {
+
+		beforeEach(function(done) {
+			tooltipFixture = fixture('basic-delay');
+			tooltip = tooltipFixture.querySelector('d2l-tooltip');
+			flush(done);
+		});
+
+		it('should instantiate the element', function() {
+			expect(tooltip.is).to.equal('d2l-tooltip');
+		});
+
+		it('should trigger the show event when target is focused', function(done) {
+			tooltipFixture.addEventListener('d2l-tooltip-show', function() {
+				requestAnimationFrame(function() {
+					expect(tooltip.hasAttribute('showing')).to.equal(true);
+					done();
+				});
+			});
+			tooltipFixture.querySelector('#basic-span-delay').focus();
 		});
 
 		it('should not trigger the hide event from mouseleave when target is focused', function(done) {

--- a/test/d2l-tooltip.html
+++ b/test/d2l-tooltip.html
@@ -128,7 +128,7 @@ describe('d2l-tooltip', function() {
 				done();
 			});
 		});
-		it('should not render if focus is lost before tooltip is rendered', function(done) {
+		it('should not render if focus is lost multiple times before tooltip is rendered', function(done) {
 			tooltipFixture.addEventListener('d2l-tooltip-show', function() {
 				expect.fail('tooltip should not have been shown');
 			});

--- a/test/d2l-tooltip.html
+++ b/test/d2l-tooltip.html
@@ -104,14 +104,15 @@ describe('d2l-tooltip', function() {
 	});
 
 	describe('basic delayed', function() {
-		beforeEach(function(){
-			this.clock = sinon.useFakeTimers();
+		var clock;
+		beforeEach(function() {
+			clock = sinon.useFakeTimers();
 			tooltipFixture = fixture('basic-delay');
 			tooltip = tooltipFixture.querySelector('d2l-tooltip');
 
 		});
-		afterEach(function(){
-			this.clock.restore();
+		afterEach(function() {
+			clock.restore();
 		});
 
 		it('should not render if focus is lost before tooltip is rendered', function(done) {
@@ -119,9 +120,9 @@ describe('d2l-tooltip', function() {
 				expect.fail('tooltip should not have been shown');
 			});
 			tooltipFixture.querySelector('#basic-span-delay').focus();
-			this.clock.tick(500);
+			clock.tick(500);
 			tooltipFixture.querySelector('#basic-span-delay').blur();
-			this.clock.tick(5000);
+			clock.tick(5000);
 			requestAnimationFrame(function() {
 				expect(tooltip.hasAttribute('showing')).to.be.equal(false);
 				done();
@@ -131,9 +132,9 @@ describe('d2l-tooltip', function() {
 			tooltipFixture.addEventListener('d2l-tooltip-show', function() {
 				expect.fail('tooltip should not have been shown');
 			});
-			for (var i=0; i < 5; i++) {
+			for (var i = 0; i < 5; i++) {
 				tooltipFixture.querySelector('#basic-span-delay').focus();
-				this.clock.tick(500);
+				clock.tick(500);
 				tooltipFixture.querySelector('#basic-span-delay').blur();
 			}
 
@@ -152,7 +153,7 @@ describe('d2l-tooltip', function() {
 			});
 
 			tooltipFixture.querySelector('#basic-span-delay').focus();
-			this.clock.tick(5000);
+			clock.tick(5000);
 
 		});
 	});

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -27,11 +27,6 @@
           "browserName": "microsoftedge",
           "platform": "Windows 10",
           "version": ""
-        },
-        {
-          "browserName": "internet explorer",
-          "platform": "Windows 10",
-          "version": "11"
         }
       ]
     }


### PR DESCRIPTION
d2l-tooltip works quite well when you immediately want to provide context for something like an icon, image.  However when using it for hover over text that has been truncated in some way, it felt jarring to immediately pop a tooltip out.

In this PR I've added the capability for a consumer to set a delay for when the tooltip is shown.  If the tooltip would be hidden before the delay has elasped the tooltip is not shown.

Demo:
![g3PkRqOEFP](https://user-images.githubusercontent.com/1779270/64579267-e5059d80-d347-11e9-9821-227d450f2aca.gif)
