### PR TITLE
fix position of triangle pointer when boundary is set

### DIFF
--- a/d2l-tooltip.js
+++ b/d2l-tooltip.js
@@ -20,7 +20,7 @@ import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';
 const $_documentContainer = document.createElement('template');
 
-$_documentContainer.innerHTML = `<dom-module id="d2l-tooltip">
+$_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-tooltip">
 	<template strip-whitespace="">
 		<style>
 			:host {
@@ -433,6 +433,10 @@ Polymer({
 		return this.boundary.right - this.boundary.left;
 	},
 
+	get boundaryCentre() {
+		return this.boundary.left + ((this.boundary.right - this.boundary.left) / 2);
+	},
+
 	_getTooltipPositions: function(targetPositions, thisRect, targetRect) {
 		var offsets = this._getOffsets(targetRect, thisRect);
 		var scrollVals = this._getScrollVals();
@@ -491,7 +495,9 @@ Polymer({
 	},
 
 	_shouldPositionUsingLeft: function(targetPositions) {
-		return !this._useBoundaries() || targetPositions.horizontalCenter > this.boundaryWidth / 4;
+		return !this._useBoundaries() ||
+			targetPositions.horizontalCenter > this.boundaryWidth / 4 ||
+			targetPositions.horizontalCenter < this.boundaryCentre;
 	},
 
 	_setTooltipStyle: function(tooltipPositions, targetPositions) {


### PR DESCRIPTION
The problem I was seeing is that when I set a boundary with a large width, the triangle was not pointing in the right place:
![image (6)](https://user-images.githubusercontent.com/1471557/71693978-a797a680-2d62-11ea-8ac6-e42c62c3a143.png)
This fix adds a check for using "left" to position, if the centre of the input is to the left of the centre of the tooltip. I still see wierdness with RTL (the width changes when I hover and un-hover), however with the wierdness it's still better than without this fix, in which case the tooltip isn't even near the input in RTL.